### PR TITLE
Merchants write scope

### DIFF
--- a/src/OAuth/OAuth2/Service/SPiD.php
+++ b/src/OAuth/OAuth2/Service/SPiD.php
@@ -18,6 +18,8 @@ use OAuth\Common\Http\Uri\UriInterface;
  */
 class SPiD extends AbstractService
 {
+    const SCOPE_MERCHANTS_WRITE = 'spid:merchants|write';
+
     private $environment;
 
     public function __construct(


### PR DESCRIPTION
It fixes invalid service scopes error (`\OAuth\OAuth2\Service\AbstractService::isValidScope`)

```
InvalidScopeException in AbstractService.php line 60:
Scope spid:merchants|write is not valid for service OAuth\OAuth2\Service\SPiD
```